### PR TITLE
Static Payload Config Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.4.4] - 2016-01-07
+### Fixed
+- Performance issue loading multiple instances of the payload config map
+
 ## [1.4.3] - 2015-12-09
 ### Fixed
 - Allow PFO Jurisdiction Level for Tax Payload
@@ -160,6 +164,7 @@ All notable changes to this project will be documented in this file.
 - HTTP API for bidirectional communication.
 - AMQP API for unidirectional messages.
 
+[1.4.4]: https://github.com/eBayEnterprise/RetailOrderManagement-SDK/compare/1.4.3...1.4.4
 [1.4.3]: https://github.com/eBayEnterprise/RetailOrderManagement-SDK/compare/1.4.2...1.4.3
 [1.4.2]: https://github.com/eBayEnterprise/RetailOrderManagement-SDK/compare/1.4.1...1.4.2
 [1.4.1]: https://github.com/eBayEnterprise/RetailOrderManagement-SDK/compare/1.4.0...1.4.1

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/AbstractConfigLocator.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/AbstractConfigLocator.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace eBayEnterprise\RetailOrderManagement\Payload;
+
+use eBayEnterprise\RetailOrderManagement\Payload\Exception\UnsupportedPayload;
+
+/**
+ * Abstract implementation of a payload locator using an array of config data
+ * to providing details on how to construct various types of payloads.
+ */
+abstract class AbstractConfigLocator implements ILocator
+{
+    /**
+     * Indicates if the locator knows about a specific type of payload.
+     *
+     * @param string
+     * @return bool
+     */
+    public function hasPayloadConfig($type)
+    {
+        return isset($this->getConfig()[$type]);
+    }
+
+    /**
+     * Get the payload configuration for a specific type of payload.
+     *
+     * @param string
+     * @return array
+     * @throws UnsupportedPayload
+     */
+    public function getPayloadConfig($type)
+    {
+        if ($this->hasPayloadConfig($type)) {
+            return $this->getConfig()[$type];
+        }
+        throw new UnsupportedPayload("No configuration found for $type.");
+    }
+
+    /**
+     * Template method for getting the blob of config data.
+     *
+     * @return array
+     */
+    abstract protected function getConfig();
+}

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/ConfigLocator.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/ConfigLocator.php
@@ -15,17 +15,30 @@
 
 namespace eBayEnterprise\RetailOrderManagement\Payload;
 
-use Psr\Log\LoggerInterface;
-
-interface IPayloadFactory
+/**
+ * Payload locator using injected configuration for describing how to construct
+ * various types of payloads.
+ */
+class ConfigLocator extends AbstractConfigLocator
 {
+    /** @var array */
+    protected $config;
+
     /**
-     * Construct a new payload instance
-     * @param  string
-     * @param  IPayloadMap | null
-     * @param  IPayload | null
-     * @param  LoggerInterface
-     * @return IPayload
+     * @param array $config Payload locator configuration
      */
-    public function buildPayload($type, IPayloadMap $cascadedPayloadMap = null, IPayload $parentPayload = null, LoggerInterface $logger = null);
+    public function __construct(array $config = [])
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Get the blob of config data.
+     *
+     * @return array
+     */
+    protected function getConfig()
+    {
+        return $this->config;
+    }
 }

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/ConfigLocatorTest.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/ConfigLocatorTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace eBayEnterprise\RetailOrderManagement\Payload;
+
+class ConfigLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_PAYLOAD_TYPE = '\eBayEnterprise\RetailOrderManagement\Payload\Test';
+    /** @var array */
+    protected $testPayloadConfig;
+    /** @var array */
+    protected $config;
+    /** @var ConfigLocator */
+    protected $locator;
+
+    public function setUp()
+    {
+        $this->testPayloadConfig = [
+            'validators' => [['validator' => 'SomeValidator', 'params' => []]],
+            'validatorIterator' => 'ValidatorIterator',
+            'schemaValidator' => 'SchemaValidator',
+            'childPayloads' => ['payloadMap' => 'PayloadMap', 'types' => []],
+        ];
+        $this->config = [self::TEST_PAYLOAD_TYPE => $this->testPayloadConfig];
+        $this->locator = new ConfigLocator($this->config);
+    }
+
+    public function testHasPayoadConfig()
+    {
+        $this->assertTrue($this->locator->hasPayloadConfig(self::TEST_PAYLOAD_TYPE));
+        $this->assertFalse($this->locator->hasPayloadConfig('NotAPayloadTestType'));
+    }
+
+    public function testGetPayloadConfig()
+    {
+        $this->assertSame(
+            $this->locator->getPayloadConfig(self::TEST_PAYLOAD_TYPE),
+            $this->testPayloadConfig
+        );
+    }
+
+    public function testUnsupportedPayloadExceptionForUnknownType()
+    {
+        $this->setExpectedException('\eBayEnterprise\RetailOrderManagement\Payload\Exception\UnsupportedPayload');
+        $this->locator->getPayloadConfig('NotAPayloadTestType');
+    }
+}

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/ConfigMapLocator.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/ConfigMapLocator.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright (c) 2013-2014 eBay Enterprise, Inc.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @copyright   Copyright (c) 2013-2014 eBay Enterprise, Inc. (http://www.ebayenterprise.com/)
+ * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ */
+
+namespace eBayEnterprise\RetailOrderManagement\Payload;
+
+/**
+ * Payload locator using a default mapping found in PayloadConfigMap.php.
+ */
+class ConfigMapLocator extends AbstractConfigLocator
+{
+    /**
+     * Array of configuration data used to describe how to construct various
+     * types of payloads. Stored as a static property so each instance doesn't
+     * need it's own copy of the configuration, which has grown quite large.
+     *
+     * @var array
+     */
+    protected static $config;
+
+    /**
+     * @param array $config Payload locator configuration
+     */
+    public function __construct()
+    {
+        if (!self::$config) {
+            self::$config = require 'PayloadConfigMap.php';
+        }
+    }
+
+    /**
+     * Get the blob of payload config data.
+     *
+     * @return array
+     */
+    protected function getConfig()
+    {
+        return self::$config;
+    }
+}

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/ILocator.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/ILocator.php
@@ -15,17 +15,24 @@
 
 namespace eBayEnterprise\RetailOrderManagement\Payload;
 
-use Psr\Log\LoggerInterface;
+use eBayEnterprise\RetailOrderManagement\Payload\Exception\UnsupportedPayload;
 
-interface IPayloadFactory
+interface ILocator
 {
     /**
-     * Construct a new payload instance
-     * @param  string
-     * @param  IPayloadMap | null
-     * @param  IPayload | null
-     * @param  LoggerInterface
-     * @return IPayload
+     * Indicates if the locator knows about a specific type of payload.
+     *
+     * @param string
+     * @return bool
      */
-    public function buildPayload($type, IPayloadMap $cascadedPayloadMap = null, IPayload $parentPayload = null, LoggerInterface $logger = null);
+    public function hasPayloadConfig($type);
+
+    /**
+     * Get the payload configuration for a specific type of payload.
+     *
+     * @param string
+     * @return array
+     * @throws UnsupportedPayload
+     */
+    public function getPayloadConfig($type);
 }

--- a/src/eBayEnterprise/RetailOrderManagement/Payload/PayloadFactory.php
+++ b/src/eBayEnterprise/RetailOrderManagement/Payload/PayloadFactory.php
@@ -16,22 +16,26 @@
 namespace eBayEnterprise\RetailOrderManagement\Payload;
 
 use eBayEnterprise\RetailOrderManagement\Payload\Exception\UnsupportedPayload;
+use eBayEnterprise\RetailOrderManagement\Payload\ConfigLocator;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
+/**
+ * Abstract factory implementation for building payload objects.
+ */
 class PayloadFactory implements IPayloadFactory
 {
-    /** @var array maps a payload type to configuration used to construct the payload */
-    protected $payloadTypeMap;
-    /** @var LoggerInterface */
-    protected $logger;
+    /** @var ILocator Maps a payload type to configuration used to construct the payload */
+    protected $locator;
 
     /**
-     * @param LoggerInterface
+     * @param ILocator
      */
-    public function __construct()
+    public function __construct(ILocator $locator = null)
     {
-        $this->payloadTypeMap = require('PayloadConfigMap.php');
+        // If no custom payload locator is used, default to a locator using
+        // the PayloadConfigMap.
+        $this->locator = $locator ?: new ConfigMapLocator;
     }
 
     /**
@@ -45,8 +49,8 @@ class PayloadFactory implements IPayloadFactory
      */
     public function buildPayload($type, IPayloadMap $cascadedPayloadMap = null, IPayload $parentPayload = null, LoggerInterface $logger = null)
     {
-        if (isset($this->payloadTypeMap[$type])) {
-            $payloadConfig = $this->payloadTypeMap[$type];
+        if ($this->locator->hasPayloadConfig($type)) {
+            $payloadConfig = $this->locator->getPayloadConfig($type);
 
             $validatorIteratorConfig = $payloadConfig['validatorIterator'];
             $validatorsConfig = $payloadConfig['validators'];


### PR DESCRIPTION
Use a locator object for looking up data on how to construct payloads. Use the locator in the PayloadFactory instead of directly depending upon the configuration in PayloadConfigMap.php. Load the configuration in PayloadConfigMap into one type of locator, using a static property to prevent the mapping from being loaded into memory more than once. This should dramatically reduce memory usage of the SDK in cases where multiple instances of the PayloadFactory are used - e.g. any payloads with subpayloads.